### PR TITLE
Add Åva gymnasium

### DIFF
--- a/lib/domains/se/taby/skola.txt
+++ b/lib/domains/se/taby/skola.txt
@@ -1,0 +1,2 @@
+Åva gymnasium
+.group


### PR DESCRIPTION
Official website: https://www.taby.se/ava-gymnasium/

Data and media technology education page: https://www.taby.se/ava-gymnasium/avas-program/teknik-innovation2/information--och-medieteknik/ 

the email used for student is firstname.lastname@skola.taby.se
and for teachers and admins its firstname.lastname@taby.se

however i could only find teacher and admin emails on the website and no proof for the student accounts execpt for my own email wich is a student email.
<img width="256" alt="image" src="https://user-images.githubusercontent.com/46608127/185948353-c74e1a01-0f6f-4a67-ab80-b427893b70fe.png">
if that is not sufficient evidence here is the offical school mail<avagymnasium@taby.se>;
